### PR TITLE
Add support for moon phase labels in MoonWidget

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(chmod:*)",
       "Bash(python3:*)",
       "Bash(convert:*)",
-      "Bash(magick:*)"
+      "Bash(magick:*)",
+      "Bash(dart analyze *)"
     ],
     "deny": []
   }

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>9.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/moon_phase/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   moon_phase: d72720758da059ee6c5eeae9ecdf71b9639874b6
 
-PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+PODFILE CHECKSUM: 0dbd5a87e0ace00c9610d2037ac22083a01f861d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -156,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -200,10 +200,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -214,6 +216,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -340,7 +343,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -417,7 +420,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -466,7 +469,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,11 +46,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,16 @@
-import UIKit
 import Flutter
+import UIKit
 
-@UIApplicationMain
-@objc class AppDelegate: FlutterAppDelegate {
+@main
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -21,6 +23,29 @@
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:moon_phase/moon_widget.dart';
+import 'package:moon_phase/moon_phase.dart';
 
 void main() {
   runApp(const MyApp());
@@ -12,7 +12,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: DefaultTabController(
-        length: 2,
+        length: 3,
         child: Scaffold(
           appBar: AppBar(
             title: const Text('MoonWidget example app'),
@@ -20,6 +20,7 @@ class MyApp extends StatelessWidget {
               tabs: [
                 Tab(text: 'Simple'),
                 Tab(text: 'Image'),
+                Tab(text: 'Labels'),
               ],
             ),
           ),
@@ -27,6 +28,7 @@ class MyApp extends StatelessWidget {
             children: [
               MoonPhasesSimple(),
               MoonPhasesImage(),
+              MoonPhasesLabels(),
             ],
           ),
         ),
@@ -34,6 +36,10 @@ class MyApp extends StatelessWidget {
     );
   }
 }
+
+// ---------------------------------------------------------------------------
+// Tab 1 – Simple
+// ---------------------------------------------------------------------------
 
 class MoonPhasesSimple extends StatelessWidget {
   const MoonPhasesSimple({Key? key}) : super(key: key);
@@ -77,6 +83,10 @@ class MoonPhasesSimple extends StatelessWidget {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Tab 2 – Image
+// ---------------------------------------------------------------------------
+
 class MoonPhasesImage extends StatelessWidget {
   const MoonPhasesImage({Key? key}) : super(key: key);
 
@@ -117,5 +127,291 @@ class MoonPhasesImage extends StatelessWidget {
       );
     }
     return list;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tab 3 – Labels
+// ---------------------------------------------------------------------------
+
+/// Dates that land on each of the 8 main phases (October 2021 lunar cycle).
+final _phaseDates = [
+  DateTime(2021, 10, 6, 11),  // New Moon
+  DateTime(2021, 10, 9, 0),   // Waxing Crescent
+  DateTime(2021, 10, 12, 23), // First Quarter
+  DateTime(2021, 10, 16, 12), // Waxing Gibbous
+  DateTime(2021, 10, 20, 14), // Full Moon
+  DateTime(2021, 10, 24, 12), // Waning Gibbous
+  DateTime(2021, 10, 28, 20), // Last Quarter
+  DateTime(2021, 11, 1, 12),  // Waning Crescent
+];
+
+/// Labels resolved by the app's i18n system at build time.
+/// In a real app, replace these strings with whatever your localization
+/// system returns (flutter_localizations, easy_localization, etc.).
+const Map<MoonPhaseName, String> _phaseLabels = {
+  MoonPhaseName.newMoon: 'phase_new_moon',
+  MoonPhaseName.waxingCrescent: 'phase_waxing_crescent',
+  MoonPhaseName.firstQuarter: 'phase_first_quarter',
+  MoonPhaseName.waxingGibbous: 'phase_waxing_gibbous',
+  MoonPhaseName.fullMoon: 'phase_full_moon',
+  MoonPhaseName.waningGibbous: 'phase_waning_gibbous',
+  MoonPhaseName.lastQuarter: 'phase_last_quarter',
+  MoonPhaseName.waningCrescent: 'phase_waning_crescent',
+};
+
+class MoonPhasesLabels extends StatefulWidget {
+  const MoonPhasesLabels({Key? key}) : super(key: key);
+
+  @override
+  State<MoonPhasesLabels> createState() => _MoonPhasesLabelsState();
+}
+
+class _MoonPhasesLabelsState extends State<MoonPhasesLabels> {
+  MoonLabelPosition _position = MoonLabelPosition.bottom;
+  double _moonSize = 48;
+  double _fontSize = 11;
+
+  bool get _isHorizontal =>
+      _position == MoonLabelPosition.left ||
+      _position == MoonLabelPosition.right;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _ControlBar(
+          position: _position,
+          moonSize: _moonSize,
+          fontSize: _fontSize,
+          onPositionChanged: (v) => setState(() => _position = v),
+          onMoonSizeChanged: (v) => setState(() => _moonSize = v),
+          onFontSizeChanged: (v) => setState(() => _fontSize = v),
+        ),
+        Expanded(
+          child: ListView(
+            padding: EdgeInsets.fromLTRB(
+              24,
+              16,
+              24,
+              24 + MediaQuery.of(context).padding.bottom,
+            ),
+            children: [
+              _Section(
+                title: 'Simple mode',
+                child: _isHorizontal
+                    ? Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: _phaseDates
+                            .map((d) => Padding(
+                                  padding: const EdgeInsets.only(bottom: 12),
+                                  child: MoonWidget.simple(
+                                    date: d,
+                                    size: _moonSize,
+                                    pixelSize: 0.5,
+                                    moonColor: Colors.amber,
+                                    earthshineColor: Colors.blueGrey.shade900,
+                                    labelPosition: _position,
+                                    phaseLabels: _phaseLabels,
+                                    labelSpacing: 8,
+                                    labelStyle: TextStyle(fontSize: _fontSize),
+                                  ),
+                                ))
+                            .toList(),
+                      )
+                    : Wrap(
+                        spacing: 16,
+                        runSpacing: 16,
+                        children: _phaseDates
+                            .map((d) => MoonWidget.simple(
+                                  date: d,
+                                  size: _moonSize,
+                                  pixelSize: 0.5,
+                                  moonColor: Colors.amber,
+                                  earthshineColor: Colors.blueGrey.shade900,
+                                  labelPosition: _position,
+                                  phaseLabels: _phaseLabels,
+                                  labelStyle: TextStyle(fontSize: _fontSize),
+                                ))
+                            .toList(),
+                      ),
+              ),
+              const SizedBox(height: 32),
+              _Section(
+                title: 'Image mode',
+                child: _isHorizontal
+                    ? Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: _phaseDates
+                            .map((d) => Padding(
+                                  padding: const EdgeInsets.only(bottom: 12),
+                                  child: MoonWidget.image(
+                                    date: d,
+                                    backgroundImageAsset: 'assets/moon_free.png',
+                                    size: _moonSize,
+                                    pixelSize: 0.5,
+                                    shadowRatio: 0.827,
+                                    earthshineColor: Colors.black87,
+                                    labelPosition: _position,
+                                    phaseLabels: _phaseLabels,
+                                    labelSpacing: 8,
+                                    labelStyle: TextStyle(fontSize: _fontSize),
+                                  ),
+                                ))
+                            .toList(),
+                      )
+                    : Wrap(
+                        spacing: 16,
+                        runSpacing: 16,
+                        children: _phaseDates
+                            .map((d) => MoonWidget.image(
+                                  date: d,
+                                  backgroundImageAsset: 'assets/moon_free.png',
+                                  size: _moonSize,
+                                  pixelSize: 0.5,
+                                  shadowRatio: 0.827,
+                                  earthshineColor: Colors.black87,
+                                  labelPosition: _position,
+                                  phaseLabels: _phaseLabels,
+                                  labelStyle: TextStyle(fontSize: _fontSize),
+                                ))
+                            .toList(),
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ControlBar extends StatelessWidget {
+  final MoonLabelPosition position;
+  final double moonSize;
+  final double fontSize;
+  final ValueChanged<MoonLabelPosition> onPositionChanged;
+  final ValueChanged<double> onMoonSizeChanged;
+  final ValueChanged<double> onFontSizeChanged;
+
+  const _ControlBar({
+    required this.position,
+    required this.moonSize,
+    required this.fontSize,
+    required this.onPositionChanged,
+    required this.onMoonSizeChanged,
+    required this.onFontSizeChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Theme.of(context).colorScheme.surface,
+      elevation: 1,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                const Text('Position:'),
+                const SizedBox(width: 8),
+                DropdownButton<MoonLabelPosition>(
+                  value: position,
+                  isDense: true,
+                  items: MoonLabelPosition.values
+                      .map((p) => DropdownMenuItem(
+                            value: p,
+                            child: Text(p.toString().split('.').last),
+                          ))
+                      .toList(),
+                  onChanged: (v) => onPositionChanged(v!),
+                ),
+              ],
+            ),
+            _SliderRow(
+              label: 'Moon',
+              value: moonSize,
+              min: 24,
+              max: 120,
+              onChanged: onMoonSizeChanged,
+            ),
+            _SliderRow(
+              label: 'Font',
+              value: fontSize,
+              min: 8,
+              max: 24,
+              onChanged: onFontSizeChanged,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SliderRow extends StatelessWidget {
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(width: 36, child: Text(label)),
+        Expanded(
+          child: Slider(
+            value: value,
+            min: min,
+            max: max,
+            onChanged: onChanged,
+          ),
+        ),
+        SizedBox(
+          width: 32,
+          child: Text(
+            value.round().toString(),
+            textAlign: TextAlign.right,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  final String title;
+  final Widget child;
+
+  const _Section({required this.title, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context)
+              .textTheme
+              .titleSmall
+              ?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        child,
+      ],
+    );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -116,33 +116,33 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   moon_phase:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.1.3"
   path:
     dependency: transitive
     description:
@@ -200,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -229,5 +229,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/moon_phase.dart
+++ b/lib/moon_phase.dart
@@ -2,6 +2,7 @@ library moon_phase;
 
 export 'moon_painter.dart' show MoonPainter;
 export 'moon_widget.dart' show MoonWidget;
+export 'moon_phase_name.dart' show MoonPhaseName, MoonPhaseNameX, MoonLabelPosition;
 
 import 'dart:math';
 

--- a/lib/moon_phase_name.dart
+++ b/lib/moon_phase_name.dart
@@ -1,0 +1,55 @@
+import 'dart:math';
+
+/// The 8 standard lunar phases.
+enum MoonPhaseName {
+  newMoon,
+  waxingCrescent,
+  firstQuarter,
+  waxingGibbous,
+  fullMoon,
+  waningGibbous,
+  lastQuarter,
+  waningCrescent,
+}
+
+extension MoonPhaseNameX on MoonPhaseName {
+  /// Default English labels, used as fallback when [MoonWidget.phaseLabels] is not provided.
+  static const Map<MoonPhaseName, String> defaultLabels = {
+    MoonPhaseName.newMoon: 'New Moon',
+    MoonPhaseName.waxingCrescent: 'Waxing Crescent',
+    MoonPhaseName.firstQuarter: 'First Quarter',
+    MoonPhaseName.waxingGibbous: 'Waxing Gibbous',
+    MoonPhaseName.fullMoon: 'Full Moon',
+    MoonPhaseName.waningGibbous: 'Waning Gibbous',
+    MoonPhaseName.lastQuarter: 'Last Quarter',
+    MoonPhaseName.waningCrescent: 'Waning Crescent',
+  };
+
+  /// Derives the phase name from a phase angle (radians, [0, 2π]).
+  ///
+  /// Convention used by [MoonPainter]: 0 = full moon, π = new moon.
+  static MoonPhaseName fromAngle(double phaseAngle) {
+    // Normalize to [0, 2π]
+    double a = phaseAngle % (2 * pi);
+    if (a < 0) a += 2 * pi;
+
+    const eighth = pi / 8; // 22.5°
+
+    if (a < eighth || a >= 15 * eighth) return MoonPhaseName.fullMoon;
+    if (a < 3 * eighth) return MoonPhaseName.waningGibbous;
+    if (a < 5 * eighth) return MoonPhaseName.lastQuarter;
+    if (a < 7 * eighth) return MoonPhaseName.waningCrescent;
+    if (a < 9 * eighth) return MoonPhaseName.newMoon;
+    if (a < 11 * eighth) return MoonPhaseName.waxingCrescent;
+    if (a < 13 * eighth) return MoonPhaseName.firstQuarter;
+    return MoonPhaseName.waxingGibbous;
+  }
+}
+
+/// Position of the phase label relative to the moon widget.
+enum MoonLabelPosition {
+  top,
+  bottom,
+  left,
+  right,
+}

--- a/lib/moon_widget.dart
+++ b/lib/moon_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'moon_painter.dart';
+import 'moon_phase.dart';
 
 class MoonWidget extends StatelessWidget {
   ///DateTime to show.
@@ -28,6 +28,27 @@ class MoonWidget extends StatelessWidget {
   ///Defaults to 1.0.
   final double shadowRatio;
 
+  /// Where to display the phase label relative to the moon. Null = no label.
+  final MoonLabelPosition? labelPosition;
+
+  /// Translated phase name strings keyed by [MoonPhaseName].
+  /// Falls back to built-in English labels for any missing key.
+  /// Pass your own i18n strings here:
+  /// ```dart
+  /// phaseLabels: {
+  ///   MoonPhaseName.newMoon: AppLocalizations.of(context)!.newMoon,
+  ///   MoonPhaseName.fullMoon: AppLocalizations.of(context)!.fullMoon,
+  ///   // …
+  /// }
+  /// ```
+  final Map<MoonPhaseName, String>? phaseLabels;
+
+  /// Optional style for the phase label text.
+  final TextStyle? labelStyle;
+
+  /// Spacing between the moon widget and the label.
+  final double labelSpacing;
+
   const MoonWidget({
     Key? key,
     required this.date,
@@ -37,6 +58,10 @@ class MoonWidget extends StatelessWidget {
     this.earthshineColor = Colors.black87,
     this.backgroundImageAsset,
     this.shadowRatio = 1.0,
+    this.labelPosition,
+    this.phaseLabels,
+    this.labelStyle,
+    this.labelSpacing = 4.0,
   }) : super(key: key);
 
   /// Simple moon with solid colors
@@ -47,6 +72,10 @@ class MoonWidget extends StatelessWidget {
     this.pixelSize = 1.0,
     this.moonColor = Colors.amber,
     this.earthshineColor = Colors.black87,
+    this.labelPosition,
+    this.phaseLabels,
+    this.labelStyle,
+    this.labelSpacing = 4.0,
   })  : backgroundImageAsset = null,
         shadowRatio = 1.0,
         super(key: key);
@@ -60,13 +89,15 @@ class MoonWidget extends StatelessWidget {
     this.pixelSize = 0.5,
     this.earthshineColor = Colors.black87,
     this.shadowRatio = 1.0,
+    this.labelPosition,
+    this.phaseLabels,
+    this.labelStyle,
+    this.labelSpacing = 4.0,
   })  : moonColor = Colors.amber,
         super(key: key);
 
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildMoon() {
     final hasBackgroundImage = backgroundImageAsset != null;
-
     final moonPaint = CustomPaint(
       size: Size(size, size),
       painter: MoonPainter(moonWidget: this, shadowOnly: hasBackgroundImage),
@@ -98,5 +129,55 @@ class MoonWidget extends StatelessWidget {
       height: size,
       child: moonPaint,
     );
+  }
+
+  Widget _buildLabel() {
+    final angle = MoonPhase().getPhaseAngle(date);
+    final name = MoonPhaseNameX.fromAngle(angle);
+    final label =
+        (phaseLabels?[name]) ?? MoonPhaseNameX.defaultLabels[name]!;
+    return Text(label, style: labelStyle);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final moon = _buildMoon();
+
+    if (labelPosition == null) return moon;
+
+    final label = _buildLabel();
+    final gap = SizedBox(
+      width: labelPosition == MoonLabelPosition.left ||
+              labelPosition == MoonLabelPosition.right
+          ? labelSpacing
+          : 0,
+      height: labelPosition == MoonLabelPosition.top ||
+              labelPosition == MoonLabelPosition.bottom
+          ? labelSpacing
+          : 0,
+    );
+
+    switch (labelPosition!) {
+      case MoonLabelPosition.top:
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [label, gap, moon],
+        );
+      case MoonLabelPosition.bottom:
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [moon, gap, label],
+        );
+      case MoonLabelPosition.left:
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [label, gap, moon],
+        );
+      case MoonLabelPosition.right:
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [moon, gap, label],
+        );
+    }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -108,26 +108,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -185,10 +185,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -214,5 +214,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
- Add `MoonPhaseName` enum and `MoonLabelPosition`
- Add `labelPosition`, `phaseLabels`, `labelStyle`, and `labelSpacing` properties to `MoonWidget`
- Implement automatic phase name calculation based on moon angle
- Add "Labels" tab to example app with interactive controls
- Update iOS example project to support newer Flutter standards and iOS 13.0
- Bump internal dependency versions and Dart SDK constraints